### PR TITLE
Improve equals() and hashCode()

### DIFF
--- a/src/com/lms/model/Author.java
+++ b/src/com/lms/model/Author.java
@@ -23,11 +23,7 @@ public final class Author {
 
 	@Override
 	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + id;
-		result = prime * result + ((name == null) ? 0 : name.hashCode());
-		return result;
+		return id;
 	}
 
 	@Override

--- a/src/com/lms/model/Author.java
+++ b/src/com/lms/model/Author.java
@@ -1,0 +1,51 @@
+package com.lms.model;
+
+public final class Author {
+	private final int id;
+	private String name;
+
+	public Author(int id, String name) {
+		this.id = id;
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public int getId() {
+		return id;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + id;
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Author other = (Author) obj;
+		if (id != other.id)
+			return false;
+		if (name == null) {
+			if (other.name != null)
+				return false;
+		} else if (!name.equals(other.name))
+			return false;
+		return true;
+	}
+}

--- a/src/com/lms/model/Author.java
+++ b/src/com/lms/model/Author.java
@@ -1,5 +1,7 @@
 package com.lms.model;
 
+import java.util.Objects;
+
 public final class Author {
 	private final int id;
 	private String name;
@@ -27,21 +29,14 @@ public final class Author {
 	}
 
 	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
+	public boolean equals(final Object obj) {
+		if (this == obj) {
 			return true;
-		if (obj == null)
+		} else if (obj instanceof Author) {
+			return id == ((Author) obj).getId()
+					&& Objects.equals(name, ((Author) obj).getName());
+		} else {
 			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		Author other = (Author) obj;
-		if (id != other.id)
-			return false;
-		if (name == null) {
-			if (other.name != null)
-				return false;
-		} else if (!name.equals(other.name))
-			return false;
-		return true;
+		}
 	}
 }

--- a/src/com/lms/model/Book.java
+++ b/src/com/lms/model/Book.java
@@ -1,5 +1,7 @@
 package com.lms.model;
 
+import java.util.Objects;
+
 public class Book {
 	private final int id;
 	private String title;
@@ -47,31 +49,16 @@ public class Book {
 	}
 
 	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
+	public boolean equals(final Object obj) {
+		if (this == obj) {
 			return true;
-		if (obj == null)
+		} else if (obj instanceof Book) {
+			return id == ((Book) obj).getId()
+					&& Objects.equals(title, ((Book) obj).getTitle())
+					&& Objects.equals(author, ((Book) obj).getAuthor())
+					&& Objects.equals(publisher, ((Book) obj).getPublisher());
+		} else {
 			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		Book other = (Book) obj;
-		if (author == null) {
-			if (other.author != null)
-				return false;
-		} else if (!author.equals(other.author))
-			return false;
-		if (id != other.id)
-			return false;
-		if (publisher == null) {
-			if (other.publisher != null)
-				return false;
-		} else if (!publisher.equals(other.publisher))
-			return false;
-		if (title == null) {
-			if (other.title != null)
-				return false;
-		} else if (!title.equals(other.title))
-			return false;
-		return true;
+		}
 	}
 }

--- a/src/com/lms/model/Book.java
+++ b/src/com/lms/model/Book.java
@@ -43,13 +43,7 @@ public class Book {
 
 	@Override
 	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((author == null) ? 0 : author.hashCode());
-		result = prime * result + id;
-		result = prime * result + ((publisher == null) ? 0 : publisher.hashCode());
-		result = prime * result + ((title == null) ? 0 : title.hashCode());
-		return result;
+		return id;
 	}
 
 	@Override

--- a/src/com/lms/model/Book.java
+++ b/src/com/lms/model/Book.java
@@ -1,0 +1,83 @@
+package com.lms.model;
+
+public class Book {
+	private final int id;
+	private String title;
+	private Author author;
+	private Publisher publisher;
+
+	public Book(int id, String title, Author author, Publisher publisher) {
+		this.id = id;
+		this.title = title;
+		this.author = author;
+		this.publisher = publisher;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public Author getAuthor() {
+		return author;
+	}
+
+	public void setAuthor(Author author) {
+		this.author = author;
+	}
+
+	public Publisher getPublisher() {
+		return publisher;
+	}
+
+	public void setPublisher(Publisher publisher) {
+		this.publisher = publisher;
+	}
+
+	public int getId() {
+		return id;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((author == null) ? 0 : author.hashCode());
+		result = prime * result + id;
+		result = prime * result + ((publisher == null) ? 0 : publisher.hashCode());
+		result = prime * result + ((title == null) ? 0 : title.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Book other = (Book) obj;
+		if (author == null) {
+			if (other.author != null)
+				return false;
+		} else if (!author.equals(other.author))
+			return false;
+		if (id != other.id)
+			return false;
+		if (publisher == null) {
+			if (other.publisher != null)
+				return false;
+		} else if (!publisher.equals(other.publisher))
+			return false;
+		if (title == null) {
+			if (other.title != null)
+				return false;
+		} else if (!title.equals(other.title))
+			return false;
+		return true;
+	}
+}

--- a/src/com/lms/model/Borrower.java
+++ b/src/com/lms/model/Borrower.java
@@ -43,13 +43,7 @@ public class Borrower {
 
 	@Override
 	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((address == null) ? 0 : address.hashCode());
-		result = prime * result + cardNo;
-		result = prime * result + ((name == null) ? 0 : name.hashCode());
-		result = prime * result + ((phone == null) ? 0 : phone.hashCode());
-		return result;
+		return cardNo;
 	}
 
 	@Override

--- a/src/com/lms/model/Borrower.java
+++ b/src/com/lms/model/Borrower.java
@@ -1,0 +1,83 @@
+package com.lms.model;
+
+public class Borrower {
+	private final int cardNo;
+	private String name;
+	private String address;
+	private String phone;
+	
+	public Borrower(int cardNo, String name, String address, String phone) {
+		this.cardNo = cardNo;
+		this.name = name;
+		this.address = address;
+		this.phone = phone;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getAddress() {
+		return address;
+	}
+
+	public void setAddress(String address) {
+		this.address = address;
+	}
+
+	public String getPhone() {
+		return phone;
+	}
+
+	public void setPhone(String phone) {
+		this.phone = phone;
+	}
+
+	public int getCardNo() {
+		return cardNo;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((address == null) ? 0 : address.hashCode());
+		result = prime * result + cardNo;
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		result = prime * result + ((phone == null) ? 0 : phone.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Borrower other = (Borrower) obj;
+		if (address == null) {
+			if (other.address != null)
+				return false;
+		} else if (!address.equals(other.address))
+			return false;
+		if (cardNo != other.cardNo)
+			return false;
+		if (name == null) {
+			if (other.name != null)
+				return false;
+		} else if (!name.equals(other.name))
+			return false;
+		if (phone == null) {
+			if (other.phone != null)
+				return false;
+		} else if (!phone.equals(other.phone))
+			return false;
+		return true;
+	}
+}

--- a/src/com/lms/model/Borrower.java
+++ b/src/com/lms/model/Borrower.java
@@ -1,5 +1,7 @@
 package com.lms.model;
 
+import java.util.Objects;
+
 public class Borrower {
 	private final int cardNo;
 	private String name;
@@ -47,31 +49,16 @@ public class Borrower {
 	}
 
 	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
+	public boolean equals(final Object obj) {
+		if (this == obj) {
 			return true;
-		if (obj == null)
+		} else if (obj instanceof Borrower) {
+			return cardNo == ((Borrower) obj).getCardNo()
+					&& Objects.equals(name, ((Borrower) obj).getName())
+					&& Objects.equals(address, ((Borrower) obj).getAddress())
+					&& Objects.equals(phone, ((Borrower) obj).getPhone());
+		} else {
 			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		Borrower other = (Borrower) obj;
-		if (address == null) {
-			if (other.address != null)
-				return false;
-		} else if (!address.equals(other.address))
-			return false;
-		if (cardNo != other.cardNo)
-			return false;
-		if (name == null) {
-			if (other.name != null)
-				return false;
-		} else if (!name.equals(other.name))
-			return false;
-		if (phone == null) {
-			if (other.phone != null)
-				return false;
-		} else if (!phone.equals(other.phone))
-			return false;
-		return true;
+		}
 	}
 }

--- a/src/com/lms/model/Branch.java
+++ b/src/com/lms/model/Branch.java
@@ -1,0 +1,67 @@
+package com.lms.model;
+
+public class Branch {
+	private final int id;
+	private String name;
+	private String address;
+	
+	public Branch(int id, String name, String address) {
+		this.id = id;
+		this.name = name;
+		this.address = address;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getAddress() {
+		return address;
+	}
+
+	public void setAddress(String address) {
+		this.address = address;
+	}
+
+	public int getId() {
+		return id;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((address == null) ? 0 : address.hashCode());
+		result = prime * result + id;
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Branch other = (Branch) obj;
+		if (address == null) {
+			if (other.address != null)
+				return false;
+		} else if (!address.equals(other.address))
+			return false;
+		if (id != other.id)
+			return false;
+		if (name == null) {
+			if (other.name != null)
+				return false;
+		} else if (!name.equals(other.name))
+			return false;
+		return true;
+	}
+}

--- a/src/com/lms/model/Branch.java
+++ b/src/com/lms/model/Branch.java
@@ -1,5 +1,7 @@
 package com.lms.model;
 
+import java.util.Objects;
+
 public class Branch {
 	private final int id;
 	private String name;
@@ -37,26 +39,15 @@ public class Branch {
 	}
 
 	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
+	public boolean equals(final Object obj) {
+		if (this == obj) {
 			return true;
-		if (obj == null)
+		} else if (obj instanceof Branch) {
+			return id == ((Branch) obj).getId()
+					&& Objects.equals(name, ((Branch) obj).getName())
+					&& Objects.equals(address, ((Branch) obj).getAddress());
+		} else {
 			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		Branch other = (Branch) obj;
-		if (address == null) {
-			if (other.address != null)
-				return false;
-		} else if (!address.equals(other.address))
-			return false;
-		if (id != other.id)
-			return false;
-		if (name == null) {
-			if (other.name != null)
-				return false;
-		} else if (!name.equals(other.name))
-			return false;
-		return true;
+		}
 	}
 }

--- a/src/com/lms/model/Branch.java
+++ b/src/com/lms/model/Branch.java
@@ -33,12 +33,7 @@ public class Branch {
 
 	@Override
 	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((address == null) ? 0 : address.hashCode());
-		result = prime * result + id;
-		result = prime * result + ((name == null) ? 0 : name.hashCode());
-		return result;
+		return id;
 	}
 
 	@Override

--- a/src/com/lms/model/Loan.java
+++ b/src/com/lms/model/Loan.java
@@ -2,6 +2,7 @@ package com.lms.model;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 public class Loan {
 	private final Book book;
@@ -48,14 +49,7 @@ public class Loan {
 
 	@Override
 	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((book == null) ? 0 : book.hashCode());
-		result = prime * result + ((borrower == null) ? 0 : borrower.hashCode());
-		result = prime * result + ((branch == null) ? 0 : branch.hashCode());
-		result = prime * result + ((dateOut == null) ? 0 : dateOut.hashCode());
-		result = prime * result + ((dueDate == null) ? 0 : dueDate.hashCode());
-		return result;
+		return Objects.hash(book, borrower, branch);
 	}
 
 	@Override

--- a/src/com/lms/model/Loan.java
+++ b/src/com/lms/model/Loan.java
@@ -1,0 +1,109 @@
+package com.lms.model;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class Loan {
+	private Book book;
+	private Borrower borrower;
+	private Branch branch;
+	private LocalDateTime dateOut;
+	private LocalDate dueDate;
+
+	public Loan(Book book, Borrower borrower, Branch branch, LocalDateTime dateOut, LocalDate dueDate) {
+		this.book = book;
+		this.borrower = borrower;
+		this.branch = branch;
+		this.dateOut = dateOut;
+		this.dueDate = dueDate;
+	}
+
+	public Book getBook() {
+		return book;
+	}
+
+	public void setBook(Book book) {
+		this.book = book;
+	}
+
+	public Borrower getBorrower() {
+		return borrower;
+	}
+
+	public void setBorrower(Borrower borrower) {
+		this.borrower = borrower;
+	}
+
+	public Branch getBranch() {
+		return branch;
+	}
+
+	public void setBranch(Branch branch) {
+		this.branch = branch;
+	}
+
+	public LocalDateTime getDateOut() {
+		return dateOut;
+	}
+
+	public void setDateOut(LocalDateTime dateOut) {
+		this.dateOut = dateOut;
+	}
+
+	public LocalDate getDueDate() {
+		return dueDate;
+	}
+
+	public void setDueDate(LocalDate dueDate) {
+		this.dueDate = dueDate;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((book == null) ? 0 : book.hashCode());
+		result = prime * result + ((borrower == null) ? 0 : borrower.hashCode());
+		result = prime * result + ((branch == null) ? 0 : branch.hashCode());
+		result = prime * result + ((dateOut == null) ? 0 : dateOut.hashCode());
+		result = prime * result + ((dueDate == null) ? 0 : dueDate.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Loan other = (Loan) obj;
+		if (book == null) {
+			if (other.book != null)
+				return false;
+		} else if (!book.equals(other.book))
+			return false;
+		if (borrower == null) {
+			if (other.borrower != null)
+				return false;
+		} else if (!borrower.equals(other.borrower))
+			return false;
+		if (branch == null) {
+			if (other.branch != null)
+				return false;
+		} else if (!branch.equals(other.branch))
+			return false;
+		if (dateOut == null) {
+			if (other.dateOut != null)
+				return false;
+		} else if (!dateOut.equals(other.dateOut))
+			return false;
+		if (dueDate == null) {
+			if (other.dueDate != null)
+				return false;
+		} else if (!dueDate.equals(other.dueDate))
+			return false;
+		return true;
+	}
+}

--- a/src/com/lms/model/Loan.java
+++ b/src/com/lms/model/Loan.java
@@ -4,9 +4,9 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public class Loan {
-	private Book book;
-	private Borrower borrower;
-	private Branch branch;
+	private final Book book;
+	private final Borrower borrower;
+	private final Branch branch;
 	private LocalDateTime dateOut;
 	private LocalDate dueDate;
 
@@ -22,24 +22,12 @@ public class Loan {
 		return book;
 	}
 
-	public void setBook(Book book) {
-		this.book = book;
-	}
-
 	public Borrower getBorrower() {
 		return borrower;
 	}
 
-	public void setBorrower(Borrower borrower) {
-		this.borrower = borrower;
-	}
-
 	public Branch getBranch() {
 		return branch;
-	}
-
-	public void setBranch(Branch branch) {
-		this.branch = branch;
 	}
 
 	public LocalDateTime getDateOut() {

--- a/src/com/lms/model/Loan.java
+++ b/src/com/lms/model/Loan.java
@@ -53,39 +53,17 @@ public class Loan {
 	}
 
 	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
+	public boolean equals(final Object obj) {
+		if (this == obj) {
 			return true;
-		if (obj == null)
+		} else if (obj instanceof Loan) {
+			return Objects.equals(book, ((Loan) obj).getBook())
+					&& Objects.equals(borrower, ((Loan) obj).getBorrower())
+					&& Objects.equals(branch, ((Loan) obj).getBranch())
+					&& Objects.equals(dateOut, ((Loan) obj).getDateOut())
+					&& Objects.equals(dueDate, ((Loan) obj).getDueDate());
+		} else {
 			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		Loan other = (Loan) obj;
-		if (book == null) {
-			if (other.book != null)
-				return false;
-		} else if (!book.equals(other.book))
-			return false;
-		if (borrower == null) {
-			if (other.borrower != null)
-				return false;
-		} else if (!borrower.equals(other.borrower))
-			return false;
-		if (branch == null) {
-			if (other.branch != null)
-				return false;
-		} else if (!branch.equals(other.branch))
-			return false;
-		if (dateOut == null) {
-			if (other.dateOut != null)
-				return false;
-		} else if (!dateOut.equals(other.dateOut))
-			return false;
-		if (dueDate == null) {
-			if (other.dueDate != null)
-				return false;
-		} else if (!dueDate.equals(other.dueDate))
-			return false;
-		return true;
+		}
 	}
 }

--- a/src/com/lms/model/Publisher.java
+++ b/src/com/lms/model/Publisher.java
@@ -48,13 +48,7 @@ public final class Publisher {
 
 	@Override
 	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((address == null) ? 0 : address.hashCode());
-		result = prime * result + id;
-		result = prime * result + ((name == null) ? 0 : name.hashCode());
-		result = prime * result + ((phone == null) ? 0 : phone.hashCode());
-		return result;
+		return id;
 	}
 
 	@Override

--- a/src/com/lms/model/Publisher.java
+++ b/src/com/lms/model/Publisher.java
@@ -1,5 +1,7 @@
 package com.lms.model;
 
+import java.util.Objects;
+
 public final class Publisher {
 	private final int id;
 	private String name;
@@ -52,31 +54,16 @@ public final class Publisher {
 	}
 
 	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
+	public boolean equals(final Object obj) {
+		if (this == obj) {
 			return true;
-		if (obj == null)
+		} else if (obj instanceof Publisher) {
+			return id == ((Publisher) obj).getId()
+					&& Objects.equals(name, ((Publisher) obj).getName())
+					&& Objects.equals(address, ((Publisher) obj).getAddress())
+					&& Objects.equals(phone, ((Publisher) obj).getPhone());
+		} else {
 			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		Publisher other = (Publisher) obj;
-		if (address == null) {
-			if (other.address != null)
-				return false;
-		} else if (!address.equals(other.address))
-			return false;
-		if (id != other.id)
-			return false;
-		if (name == null) {
-			if (other.name != null)
-				return false;
-		} else if (!name.equals(other.name))
-			return false;
-		if (phone == null) {
-			if (other.phone != null)
-				return false;
-		} else if (!phone.equals(other.phone))
-			return false;
-		return true;
+		}
 	}
 }

--- a/src/com/lms/model/Publisher.java
+++ b/src/com/lms/model/Publisher.java
@@ -1,0 +1,88 @@
+package com.lms.model;
+
+public final class Publisher {
+	private final int id;
+	private String name;
+	private String address;
+	private String phone;
+
+	public Publisher(int id, String name) {
+		this.id = id;
+		this.name = name;
+	}
+	
+	public Publisher(int id, String name, String address, String phone) {
+		this.id = id;
+		this.name = name;
+		this.address = address;
+		this.phone = phone;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getAddress() {
+		return address;
+	}
+
+	public void setAddress(String address) {
+		this.address = address;
+	}
+
+	public String getPhone() {
+		return phone;
+	}
+
+	public void setPhone(String phone) {
+		this.phone = phone;
+	}
+
+	public int getId() {
+		return id;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((address == null) ? 0 : address.hashCode());
+		result = prime * result + id;
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		result = prime * result + ((phone == null) ? 0 : phone.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Publisher other = (Publisher) obj;
+		if (address == null) {
+			if (other.address != null)
+				return false;
+		} else if (!address.equals(other.address))
+			return false;
+		if (id != other.id)
+			return false;
+		if (name == null) {
+			if (other.name != null)
+				return false;
+		} else if (!name.equals(other.name))
+			return false;
+		if (phone == null) {
+			if (other.phone != null)
+				return false;
+		} else if (!phone.equals(other.phone))
+			return false;
+		return true;
+	}
+}


### PR DESCRIPTION
The auto-generated equals() and hashCode() implementations are better than nothing, but IMO aren't good enough. So this pull request suggests three changes, one just to `Loan` and two across the board:

- In `Loan`, the three "identity" fields (book, borrower, and branch) should be (like `id` in every other class) made `final`.
- In every model class, `hashCode()` should return a value based only on its "identity" field(s)---usually just `return id`.
- IMO, the generated `equals()` is (basically) *correct* but *ugly*, and my attempt at improving it also cut the number of lines involved by 75 lines.