### PR TITLE
Fix DAO interface signatures.

### DIFF
--- a/src/com/lms/dao/AuthorDao.java
+++ b/src/com/lms/dao/AuthorDao.java
@@ -1,7 +1,9 @@
 package com.lms.dao;
 
+import java.sql.SQLException;
+
 import com.lms.model.Author;
 
 public interface AuthorDao extends Dao<Author> {
-	public abstract void create(String authorName);
+	public abstract void create(String authorName) throws SQLException;
 }

--- a/src/com/lms/dao/AuthorDao.java
+++ b/src/com/lms/dao/AuthorDao.java
@@ -5,5 +5,5 @@ import java.sql.SQLException;
 import com.lms.model.Author;
 
 public interface AuthorDao extends Dao<Author> {
-	public abstract void create(String authorName) throws SQLException;
+	public abstract Author create(String authorName) throws SQLException;
 }

--- a/src/com/lms/dao/BookDao.java
+++ b/src/com/lms/dao/BookDao.java
@@ -1,9 +1,11 @@
 package com.lms.dao;
 
+import java.sql.SQLException;
+
 import com.lms.model.Author;
 import com.lms.model.Book;
 import com.lms.model.Publisher;
 
 public interface BookDao extends Dao<Book> {
-	public abstract void create(String title, Author author, Publisher publisher);
+	public abstract void create(String title, Author author, Publisher publisher) throws SQLException;
 }

--- a/src/com/lms/dao/BookDao.java
+++ b/src/com/lms/dao/BookDao.java
@@ -7,5 +7,5 @@ import com.lms.model.Book;
 import com.lms.model.Publisher;
 
 public interface BookDao extends Dao<Book> {
-	public abstract void create(String title, Author author, Publisher publisher) throws SQLException;
+	public abstract Book create(String title, Author author, Publisher publisher) throws SQLException;
 }

--- a/src/com/lms/dao/BookLoans.java
+++ b/src/com/lms/dao/BookLoans.java
@@ -1,5 +1,6 @@
 package com.lms.dao;
 
+import java.sql.SQLException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -9,5 +10,5 @@ import com.lms.model.Branch;
 import com.lms.model.Loan;
 
 public interface BookLoans extends Dao<Loan> {
-	public abstract void create(Book book, Borrower borrower, Branch branch, LocalDateTime dateOut, LocalDate dueDate);
+	public abstract void create(Book book, Borrower borrower, Branch branch, LocalDateTime dateOut, LocalDate dueDate) throws SQLException;
 }

--- a/src/com/lms/dao/BookLoans.java
+++ b/src/com/lms/dao/BookLoans.java
@@ -10,5 +10,5 @@ import com.lms.model.Branch;
 import com.lms.model.Loan;
 
 public interface BookLoans extends Dao<Loan> {
-	public abstract void create(Book book, Borrower borrower, Branch branch, LocalDateTime dateOut, LocalDate dueDate) throws SQLException;
+	public abstract Loan create(Book book, Borrower borrower, Branch branch, LocalDateTime dateOut, LocalDate dueDate) throws SQLException;
 }

--- a/src/com/lms/dao/BorrowerDao.java
+++ b/src/com/lms/dao/BorrowerDao.java
@@ -1,7 +1,9 @@
 package com.lms.dao;
 
+import java.sql.SQLException;
+
 import com.lms.model.Borrower;
 
 public interface BorrowerDao extends Dao<Borrower> {
-	public abstract void create(String borrowerName, String borrowerAddress, String borrowerPhone);
+	public abstract void create(String borrowerName, String borrowerAddress, String borrowerPhone) throws SQLException;
 }

--- a/src/com/lms/dao/BorrowerDao.java
+++ b/src/com/lms/dao/BorrowerDao.java
@@ -5,5 +5,5 @@ import java.sql.SQLException;
 import com.lms.model.Borrower;
 
 public interface BorrowerDao extends Dao<Borrower> {
-	public abstract void create(String borrowerName, String borrowerAddress, String borrowerPhone) throws SQLException;
+	public abstract Borrower create(String borrowerName, String borrowerAddress, String borrowerPhone) throws SQLException;
 }

--- a/src/com/lms/dao/CopiesDao.java
+++ b/src/com/lms/dao/CopiesDao.java
@@ -1,14 +1,15 @@
 package com.lms.dao;
 
+import java.sql.SQLException;
 import java.util.Map;
 
 import com.lms.model.Book;
 import com.lms.model.Branch;
 
 public interface CopiesDao {
-	public abstract int getCopies(Branch branch, Book book); // if no copies, returns 0
-	public abstract void setCopies(Branch branch , Book book, int noOfCopies); // if int is 0, delete
-	Map<Book, Integer> getAllBranchCopies(Branch branch);
-	Map<Branch, Integer> getAllBookCopies(Book book);
-	Map<Branch, Map<Book, Integer>> getAllCopies();
+	public abstract int getCopies(Branch branch, Book book) throws SQLException; // if no copies, returns 0
+	public abstract void setCopies(Branch branch , Book book, int noOfCopies) throws SQLException; // if int is 0, delete
+	Map<Book, Integer> getAllBranchCopies(Branch branch) throws SQLException;
+	Map<Branch, Integer> getAllBookCopies(Book book) throws SQLException;
+	Map<Branch, Map<Book, Integer>> getAllCopies() throws SQLException;
 }

--- a/src/com/lms/dao/Dao.java
+++ b/src/com/lms/dao/Dao.java
@@ -1,10 +1,11 @@
 package com.lms.dao;
 
+import java.sql.SQLException;
 import java.util.List;
 
 public interface Dao <T> {
-	public abstract void update(T t);
-	public abstract void delete(T t);
-	public abstract T get(int id);
-	public abstract List<T> getAll();
+	public abstract void update(T t) throws SQLException;
+	public abstract void delete(T t) throws SQLException;
+	public abstract T get(int id) throws SQLException;
+	public abstract List<T> getAll() throws SQLException;
 }

--- a/src/com/lms/dao/LibraryBranchDao.java
+++ b/src/com/lms/dao/LibraryBranchDao.java
@@ -1,7 +1,9 @@
 package com.lms.dao;
 
+import java.sql.SQLException;
+
 import com.lms.model.Branch;
 
 public interface LibraryBranchDao extends Dao<Branch> {
-	public abstract void create(String branchName, String branchAddress);
+	public abstract void create(String branchName, String branchAddress) throws SQLException;
 }

--- a/src/com/lms/dao/LibraryBranchDao.java
+++ b/src/com/lms/dao/LibraryBranchDao.java
@@ -5,5 +5,5 @@ import java.sql.SQLException;
 import com.lms.model.Branch;
 
 public interface LibraryBranchDao extends Dao<Branch> {
-	public abstract void create(String branchName, String branchAddress) throws SQLException;
+	public abstract Branch create(String branchName, String branchAddress) throws SQLException;
 }

--- a/src/com/lms/dao/PublisherDao.java
+++ b/src/com/lms/dao/PublisherDao.java
@@ -1,7 +1,9 @@
 package com.lms.dao;
 
+import java.sql.SQLException;
+
 import com.lms.model.Publisher;
 
 public interface PublisherDao extends Dao<Publisher> {
-	public abstract void create(String publisherName, String publisherAddress, String publisherPhone);
+	public abstract void create(String publisherName, String publisherAddress, String publisherPhone) throws SQLException;
 }

--- a/src/com/lms/dao/PublisherDao.java
+++ b/src/com/lms/dao/PublisherDao.java
@@ -5,5 +5,5 @@ import java.sql.SQLException;
 import com.lms.model.Publisher;
 
 public interface PublisherDao extends Dao<Publisher> {
-	public abstract void create(String publisherName, String publisherAddress, String publisherPhone) throws SQLException;
+	public abstract Publisher create(String publisherName, String publisherAddress, String publisherPhone) throws SQLException;
 }


### PR DESCRIPTION
Two things here:

- Making all DAO methods declare themselves to throw `SQLException`, so their implementations *can*. Types lower on the inheritance tree can remove or narrow the type of exception they throw, but cannot widen it or add new exceptions (unless they're unchecked exceptions, which the compiler seems to ignore in such signatures).
- Making create() methods return the objects they create.