### PR TITLE
Fix loan DAO name and signatures

### DIFF
--- a/src/com/lms/dao/BookLoansDao.java
+++ b/src/com/lms/dao/BookLoansDao.java
@@ -10,7 +10,7 @@ import com.lms.model.Borrower;
 import com.lms.model.Branch;
 import com.lms.model.Loan;
 
-public interface BookLoans {
+public interface BookLoansDao {
 	public abstract Loan create(Book book, Borrower borrower, Branch branch, LocalDateTime dateOut, LocalDate dueDate) throws SQLException;
 	public abstract void update(Book book) throws SQLException;
 	public abstract void delete(Book book) throws SQLException;

--- a/src/com/lms/dao/BookLoansDao.java
+++ b/src/com/lms/dao/BookLoansDao.java
@@ -12,8 +12,8 @@ import com.lms.model.Loan;
 
 public interface BookLoansDao {
 	public abstract Loan create(Book book, Borrower borrower, Branch branch, LocalDateTime dateOut, LocalDate dueDate) throws SQLException;
-	public abstract void update(Book book) throws SQLException;
-	public abstract void delete(Book book) throws SQLException;
-	public abstract Book get(Book book, Borrower borrower, Branch branch) throws SQLException;
-	public abstract List<Book> getAll() throws SQLException;
+	public abstract void update(Loan loan) throws SQLException;
+	public abstract void delete(Loan loan) throws SQLException;
+	public abstract Loan get(Book book, Borrower borrower, Branch branch) throws SQLException;
+	public abstract List<Loan> getAll() throws SQLException;
 }


### PR DESCRIPTION
Two things here:

- A DAO interface should have a name indicating that; `BookLoans`, alone of the classes in that package, did not; I renamed it to `BookLoansDao`.
- The methods other than create() took or returned `Book` rather than `Loan`; I fixed that.